### PR TITLE
fix for missing csrf token

### DIFF
--- a/FantiaDownloader.js
+++ b/FantiaDownloader.js
@@ -242,6 +242,14 @@
 
 			this.metaJson = {};
 			this.metaData = {};
+			
+			if (window.csrfToken) {
+				$.ajaxSetup({
+					headers: {
+						"x-csrf-token": window.csrfToken
+					}
+				});
+			}
 			let self = this;
 			$.get(this.jsonUrl, (json) => {
 				self.metaJson = json;


### PR DESCRIPTION
fantia added a check for csrf token which breaks the plugin, this fixes it.