### PR TITLE
修正過往合輯頁面的下載按鈕有時候會消失的問題

### DIFF
--- a/FantiaDownloader.js
+++ b/FantiaDownloader.js
@@ -195,8 +195,12 @@
 			});
 			// for post
 			$(`.the-post .post-thumbnail .img-default`).closest(`div.post-thumbnail`).before(`<div ng-if="$ctrl.isVisibleAndMulti()" class="ng-scope"><div class="text-center"><div class="btn-group btn-group-tabs mb-20" role="group"></div></div></div>`);
-			window.getDownLoadButton();
-			clearInterval(init);
+			
+			// make sure the button has been inserted before stopping interval.
+			if ($(`div[role="group"]`).length) {
+				window.getDownLoadButton();
+				clearInterval(init);
+			}
 		}
 	}, 500);
 


### PR DESCRIPTION
有些含有大量圖片的過往合輯頁面，似乎因為載入速度較慢的關係，有時候會造成下載按鈕不見。
這個 PR 在 `init` 的地方加了一個 if 條件來確保按鈕有被放入。