### PR TITLE
修正zip下載會產生多餘的資料夾

### DIFF
--- a/FantiaDownloader.js
+++ b/FantiaDownloader.js
@@ -715,21 +715,22 @@
 		}
 
 		paramsParser(type, fmt) {
+			const replaceSlash = `_`;
 			let o = {
 				user: () => {
-					return this.metaData.user || $("h1.fanclub-name>a").text();
+					return (this.metaData.user || $("h1.fanclub-name>a").text()).replace(/\/|\\/g, replaceSlash);
 				},
 				uid: () => {
 					return this.metaData.uid || this.authorId;
 				},
 				postTitle: () => {
-					return this.metaData.postTitle || $("h1.post-title").text();
+					return (this.metaData.postTitle || $("h1.post-title").text()).replace(/\/|\\/g, replaceSlash);
 				},
 				postId: () => {
 					return this.metaData.postId || window.location.href.split("/").pop();
 				},
 				boxTitle: () => {
-					return this.metaData.boxTitle || this.button.closest("div.post-content-inner").find('h2').text();
+					return (this.metaData.boxTitle || this.button.closest("div.post-content-inner").find('h2').text()).replace(/\/|\\/g, replaceSlash);
 				},
 				plan: () => {
 					let feeStr = this.metaData.plan || this.button.closest("div.post-content-inner").find(`div.post-content-for strong.ng-binding`).text();

--- a/FantiaDownloader.js
+++ b/FantiaDownloader.js
@@ -735,8 +735,8 @@
 				plan: () => {
 					let feeStr = this.metaData.plan || this.button.closest("div.post-content-inner").find(`div.post-content-for strong.ng-binding`).text();
 					let match = this.metaData.plan || feeStr.match(new RegExp(/（\d+円）以上限定$/g));
-					if (match != null) return this.metaData.plan || feeStr.replace(match[0], ``);
-					return this.metaData.plan || `一般公開`;
+					if (match != null) return (this.metaData.plan || feeStr.replace(match[0], ``)).replace(/\/|\\/g, replaceSlash);
+					return (this.metaData.plan || `一般公開`).replace(/\/|\\/g, replaceSlash);
 				},
 				fee: () => {
 					let feeStr = this.metaData.fee || this.button.closest("div.post-content-inner").find(`div.post-content-for strong.ng-binding`).text();


### PR DESCRIPTION
如果`創作者名稱`、`投稿標題`、`圖片區標題`和`訂閱方案名`有包含斜/反斜線的話，zip下載會把檔案名稱拆成資料夾。

e.g. 檔案名稱：`{authorName} - {titleNameWith/Slash}.{ext}`
預想情況
```
zipDownload.zip
└ authorName - titleNameWith/Slash.png
```
實際情況
```
zipDownload.zip
└ authorName - titleNameWith
    └ Slash.png
```