### PR TITLE
修正無法關閉作者特訂設定

### DIFF
--- a/FantiaDownloader.js
+++ b/FantiaDownloader.js
@@ -235,16 +235,24 @@
 						fileName: g.generalSaveFile
 					}
 				});
-				if (this.cookie[`authorId_${authorId}`] || this.cookie[`authorId_${authorId}`] == `On`) {
+				if (this.cookie[`authorId_${authorId}`]) {
+					// `authorId_${authorId}` exist in cookie.
+
+					// load authorSave settings even when authorSave is off.
 					let a = this.cookieParser([`authorSaveZIP_${authorId}`, `authorSaveFile_${authorId}`]);
-					this[`authorId_${authorId}`] = `On`;
 					this.setCookie({
-						authorSaveCheck: `On`,
 						authorSave: {
 							zipName: a[`authorSaveZIP_${authorId}`],
 							fileName: a[`authorSaveFile_${authorId}`]
 						}
 					});
+
+					if (this.cookie[`authorId_${authorId}`] === 'On') {
+						this[`authorId_${authorId}`] = `On`;
+						this.setCookie({
+							authorSaveCheck: `On`
+						});
+					}
 				}
 			}
 			this.saveCookie(false);
@@ -288,6 +296,8 @@
 					cookie[`authorId_${this.authorId}`] = 'On';
 					cookie[`authorSaveZIP_${this.authorId}`] = this.cookie.authorSave.zipName;
 					cookie[`authorSaveFile_${this.authorId}`] = this.cookie.authorSave.fileName;
+				} else {
+					cookie[`authorId_${this.authorId}`] = 'Off';
 				}
 				this.updateCookie(cookie);
 			} else {

--- a/FantiaDownloader.js
+++ b/FantiaDownloader.js
@@ -242,8 +242,8 @@
 					let a = this.cookieParser([`authorSaveZIP_${authorId}`, `authorSaveFile_${authorId}`]);
 					this.setCookie({
 						authorSave: {
-							zipName: a[`authorSaveZIP_${authorId}`],
-							fileName: a[`authorSaveFile_${authorId}`]
+							zipName: a[`authorSaveZIP_${authorId}`] || this.defaultCookie(`authorSave`).zipName,
+							fileName: a[`authorSaveFile_${authorId}`] || this.defaultCookie(`authorSave`).fileName
 						}
 					});
 


### PR DESCRIPTION
一旦開啟作者特訂後就無法改回全域設定，即使將設定改回全域設定當下會生效，重新載入頁面後就會被強制設定成使用作者特訂命名。