### PR TITLE
修正部分標題會造成下載失敗

### DIFF
--- a/FantiaDownloader.js
+++ b/FantiaDownloader.js
@@ -734,28 +734,38 @@
 		}
 
 		paramsParser(type, fmt) {
-			const replaceSlash = `_`;
+			const REPLACE_CHAR = `_`;
 			let o = {
 				user: () => {
-					return (this.metaData.user || $("h1.fanclub-name>a").text()).replace(/\/|\\/g, replaceSlash);
+					return (this.metaData.user || $("h1.fanclub-name>a").text()).replace(/\/|\\/g, REPLACE_CHAR);
 				},
 				uid: () => {
 					return this.metaData.uid || this.authorId;
 				},
 				postTitle: () => {
-					return (this.metaData.postTitle || $("h1.post-title").text()).replace(/\/|\\/g, replaceSlash);
+					return (this.metaData.postTitle || $("h1.post-title").text())
+						.replace(/\/|\\/g, REPLACE_CHAR)	// replace forward/backward slash
+						.replace(/^ +| +$/g, REPLACE_CHAR); // replace leading/trailing space
 				},
 				postId: () => {
 					return this.metaData.postId || window.location.href.split("/").pop();
 				},
 				boxTitle: () => {
-					return (this.metaData.boxTitle || this.button.closest("div.post-content-inner").find('h2').text()).replace(/\/|\\/g, replaceSlash);
+					return (this.metaData.boxTitle || this.button.closest("div.post-content-inner").find('h2').text())
+						.replace(/\/|\\/g, REPLACE_CHAR)	// replace forward/backward slash
+						.replace(/^ +| +$/g, REPLACE_CHAR); // replace leading/trailing space
 				},
 				plan: () => {
 					let feeStr = this.metaData.plan || this.button.closest("div.post-content-inner").find(`div.post-content-for strong.ng-binding`).text();
 					let match = this.metaData.plan || feeStr.match(new RegExp(/（\d+円）以上限定$/g));
-					if (match != null) return (this.metaData.plan || feeStr.replace(match[0], ``)).replace(/\/|\\/g, replaceSlash);
-					return (this.metaData.plan || `一般公開`).replace(/\/|\\/g, replaceSlash);
+					if (match != null) {
+						return (this.metaData.plan || feeStr.replace(match[0], ``))
+							.replace(/\/|\\/g, REPLACE_CHAR)	// replace forward/backward slash
+							.replace(/^ +| +$/g, REPLACE_CHAR); // replace leading/trailing space
+					}
+					return (this.metaData.plan || `一般公開`)
+						.replace(/\/|\\/g, REPLACE_CHAR)	// replace forward/backward slash
+						.replace(/^ +| +$/g, REPLACE_CHAR); // replace leading/trailing space
 				},
 				fee: () => {
 					let feeStr = this.metaData.fee || this.button.closest("div.post-content-inner").find(`div.post-content-for strong.ng-binding`).text();

--- a/FantiaDownloader.js
+++ b/FantiaDownloader.js
@@ -745,7 +745,7 @@
 				postTitle: () => {
 					return (this.metaData.postTitle || $("h1.post-title").text())
 						.replace(/\/|\\/g, REPLACE_CHAR)	// replace forward/backward slash
-						.replace(/^ +| +$/g, REPLACE_CHAR); // replace leading/trailing space
+						.replace(/^ +| +$|^\.|\.$/g, REPLACE_CHAR); // replace invalid leading/trailing character
 				},
 				postId: () => {
 					return this.metaData.postId || window.location.href.split("/").pop();
@@ -753,7 +753,7 @@
 				boxTitle: () => {
 					return (this.metaData.boxTitle || this.button.closest("div.post-content-inner").find('h2').text())
 						.replace(/\/|\\/g, REPLACE_CHAR)	// replace forward/backward slash
-						.replace(/^ +| +$/g, REPLACE_CHAR); // replace leading/trailing space
+						.replace(/^ +| +$|^\.|\.$/g, REPLACE_CHAR); // replace invalid leading/trailing character
 				},
 				plan: () => {
 					let feeStr = this.metaData.plan || this.button.closest("div.post-content-inner").find(`div.post-content-for strong.ng-binding`).text();
@@ -761,11 +761,11 @@
 					if (match != null) {
 						return (this.metaData.plan || feeStr.replace(match[0], ``))
 							.replace(/\/|\\/g, REPLACE_CHAR)	// replace forward/backward slash
-							.replace(/^ +| +$/g, REPLACE_CHAR); // replace leading/trailing space
+							.replace(/^ +| +$|^\.|\.$/g, REPLACE_CHAR); // replace invalid leading/trailing character
 					}
 					return (this.metaData.plan || `一般公開`)
 						.replace(/\/|\\/g, REPLACE_CHAR)	// replace forward/backward slash
-						.replace(/^ +| +$/g, REPLACE_CHAR); // replace leading/trailing space
+						.replace(/^ +| +$|^\.|\.$/g, REPLACE_CHAR); // replace invalid leading/trailing character
 				},
 				fee: () => {
 					let feeStr = this.metaData.fee || this.button.closest("div.post-content-inner").find(`div.post-content-for strong.ng-binding`).text();


### PR DESCRIPTION
部分標題的開頭或結尾有包含 `.` 和 `空格` 的情況下會造成下載失敗。
e.g. 
```
fmt = {postTitle}/file.{ext}

postTitle = "title ";
before fix: "title /file.png"    // invalid folder name
after fix: "title_/file.png"

postTitle = "title...";
before fix: "title.../file.png"    // invalid folder name
after fix: "title.._/file.png"
```